### PR TITLE
Fix UndefinedBehaviorSanitizer: turbob64sse.c:418:25: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'

### DIFF
--- a/turbob64sse.c
+++ b/turbob64sse.c
@@ -415,7 +415,7 @@ unsigned cpuisa(void) {
             if(c[1] & (1<<27))      _cpuisa |= AVX512ER;
             if(c[1] & (1<<28))      _cpuisa |= AVX512CD;
             if(c[1] & (1<<30))      _cpuisa |= AVX512BW;
-            if(c[1] & (1<<31))      _cpuisa |= AVX512VL;
+            if(c[1] & (1u<<31))     _cpuisa |= AVX512VL;
             if(c[2] & (1<< 1))      _cpuisa |= AVX512VBMI;
             if(c[2] & (1<<11))      _cpuisa |= AVX512VNNI;
             if(c[2] & (1<< 6))      _cpuisa |= AVX512VBMI2;


### PR DESCRIPTION
While running ClickHouse tests on different servers with several sanitizers we encounter this error under UndefinedSanitizer.
```
Logging trace to /var/log/clickhouse-server/clickhouse-server.log
Logging errors to /var/log/clickhouse-server/clickhouse-server.err.log
../contrib/base64/turbob64sse.c:418:25: runtime error: left shift of 1 by 31 places cannot be represented in type 'int'
    #0 0x1a70894c in cpuisa /build/obj-x86_64-linux-gnu/../contrib/base64/turbob64sse.c:418:25
    #1 0x1a708b18 in tb64ini /build/obj-x86_64-linux-gnu/../contrib/base64/turbob64sse.c:485:13
    #2 0x198e52ec in DB::registerFunctionBase64Encode(DB::FunctionFactory&) (/usr/bin/clickhouse+0x198e52ec)
    #3 0x198b6c75 in DB::registerFunctionsString(DB::FunctionFactory&) (/usr/bin/clickhouse+0x198b6c75)
    #4 0x1696f486 in DB::registerFunctions() (/usr/bin/clickhouse+0x1696f486)
    #5 0x15390b4f in DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > const&) /build/obj-x86_64-linux-gnu/../programs/server/Server.cpp:220:5
    #6 0x20c4d36f in Poco::Util::Application::run() /build/obj-x86_64-linux-gnu/../contrib/poco/Util/src/Application.cpp:334:8
    #7 0x1538fd9d in DB::Server::run() /build/obj-x86_64-linux-gnu/../programs/server/Server.cpp:184:25
    #8 0x153b0eb0 in mainEntryClickHouseServer(int, char**) /build/obj-x86_64-linux-gnu/../programs/server/Server.cpp:1084:20
    #9 0x1531cdce in main /build/obj-x86_64-linux-gnu/../programs/main.cpp:324:12
    #10 0x7fd9ab5761e2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x271e2)
    #11 0x152fb02d in _start (/usr/bin/clickhouse+0x152fb02d)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../contrib/base64/turbob64sse.c:418:25 in
```
I'm running UBSAN build on server with **avx512vl**
```
cpuinfo
flags    : fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon rep_good nopl xtopology cpuid tsc_known_freq pni pclmulqdq vmx ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single pti tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm mpx avx512f avx512dq rdseed adx smap clflushopt clwb avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves arat umip pku ospke
```

To fix signed integer overflow I propose this one char fix. `1u` has uint type and there will be no error.

If you need more context, feel free to ask me about it.

ClickHouse issue: https://github.com/ClickHouse/ClickHouse/issues/12318